### PR TITLE
ash: allow standalone mode to be detected by $-

### DIFF
--- a/shell/ash.c
+++ b/shell/ash.c
@@ -333,7 +333,7 @@ static const char *const optletters_optnames[] = {
 	"u"   "nounset",
 	"\0"  "vi",
 /* Magisk: toggle whether use standalone shell mode */
-	"\0"  "standalone"
+	"S"  "standalone"
 #if BASH_PIPEFAIL
 	,"\0"  "pipefail"
 #endif


### PR DESCRIPTION
Capital S should be free for use, certainly is within this context